### PR TITLE
Fixed Timing Attack (Username/Password Enumeration)

### DIFF
--- a/lib/clearance/password_strategies/bcrypt.rb
+++ b/lib/clearance/password_strategies/bcrypt.rb
@@ -16,6 +16,9 @@ module Clearance
       def authenticated?(password)
         if encrypted_password.present?
           ::BCrypt::Password.new(encrypted_password) == password
+        else
+          ::BCrypt::Password.create(password)
+          false
         end
       end
 


### PR DESCRIPTION
:gear: **Fix:**

The fix is implemented by performing a `bcrypt` check even if a user doesn't exist so that the response time wouldn't differ much preventing an attacker to perform user enumeration.

:question: **How:**

The fix would pass the input password into `::BCrypt::Password` method even if the given user doesn't exist. This would result in a response time that doesn't differ from the request where the user exists and doesn't.

**Implementation:**

```ruby
def authenticated?(password)
  if encrypted_password.present?
    ::BCrypt::Password.new(encrypted_password) == password
  else
    ::BCrypt::Password.create(password)
    false
  end
end
```

The fix is as suggested by the issue author (https://github.com/thoughtbot/clearance/issues/636#issue-129332734).

<hr>

### :v: Fixed!

<hr>